### PR TITLE
Fix instant deserialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,3 +270,11 @@ spec:
         cpu: 50m
 
 ```
+
+# Changes:
+
+## 5.4.24
+
+### Added:
+
++ Custom serializer for `java.time.Instant` (backward compatibility with old jackson serialization)

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@
 
 kotlin.code.style=official
 
-release_version=5.4.23
+release_version=5.4.24
 
 docker_image_name=

--- a/src/main/kotlin/com/exactpro/th2/rptdataprovider/Context.kt
+++ b/src/main/kotlin/com/exactpro/th2/rptdataprovider/Context.kt
@@ -35,6 +35,7 @@ import com.exactpro.th2.rptdataprovider.entities.filters.messages.MessageBodyFil
 import com.exactpro.th2.rptdataprovider.entities.filters.messages.MessageTypeFilter
 import com.exactpro.th2.rptdataprovider.entities.internal.MessageWithMetadata
 import com.exactpro.th2.rptdataprovider.entities.responses.BaseEventEntity
+import com.exactpro.th2.rptdataprovider.entities.serialization.InstantBackwardCompatibilitySerializer
 import com.exactpro.th2.rptdataprovider.handlers.SearchEventsHandler
 import com.exactpro.th2.rptdataprovider.handlers.SearchMessagesHandler
 import com.exactpro.th2.rptdataprovider.producers.EventProducer
@@ -44,8 +45,10 @@ import com.exactpro.th2.rptdataprovider.services.cradle.CradleService
 import com.exactpro.th2.rptdataprovider.services.rabbitmq.RabbitMqService
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.ktor.http.*
+import java.time.Instant
 
 @Suppress("MemberVisibilityCanBePrivate")
 class Context(
@@ -58,7 +61,10 @@ class Context(
 
     val jacksonMapper: ObjectMapper = jacksonObjectMapper()
         .enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
-        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES),
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .registerModule(SimpleModule("backward_compatibility").apply {
+            addSerializer(Instant::class.java, InstantBackwardCompatibilitySerializer)
+        }),
 
     val cradleManager: CradleManager,
     val messageRouterRawBatch: MessageRouter<MessageGroupBatch>,

--- a/src/main/kotlin/com/exactpro/th2/rptdataprovider/entities/serialization/InstantBackwardCompatibilitySerializer.kt
+++ b/src/main/kotlin/com/exactpro/th2/rptdataprovider/entities/serialization/InstantBackwardCompatibilitySerializer.kt
@@ -1,0 +1,25 @@
+package com.exactpro.th2.rptdataprovider.entities.serialization
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import java.time.Instant
+
+@Deprecated("used to keep backward compatibility with previous version of jackson. Should be removed when migrated to a normal format for instant")
+object InstantBackwardCompatibilitySerializer : StdSerializer<Instant>(Instant::class.java) {
+    private const val serialVersionUID: Long = 6738326988027583780L
+
+    override fun serialize(value: Instant, gen: JsonGenerator, provider: SerializerProvider) {
+        with(gen) {
+            writeStartObject(value)
+            writeField("epochSecond", value.epochSecond)
+            writeField("nano", value.nano.toLong())
+            writeEndObject()
+        }
+    }
+
+    private fun JsonGenerator.writeField(name: String, value: Long) {
+        writeFieldName(name)
+        writeNumber(value)
+    }
+}

--- a/src/main/kotlin/com/exactpro/th2/rptdataprovider/entities/serialization/InstantBackwardCompatibilitySerializer.kt
+++ b/src/main/kotlin/com/exactpro/th2/rptdataprovider/entities/serialization/InstantBackwardCompatibilitySerializer.kt
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
 package com.exactpro.th2.rptdataprovider.entities.serialization
 
 import com.fasterxml.jackson.core.JsonGenerator


### PR DESCRIPTION
The new version of Jackson does not support Instant serialization by default. A custom serializer was added for backward compatibility.